### PR TITLE
feat(consume): add coinpurse support

### DIFF
--- a/consume.alias
+++ b/consume.alias
@@ -127,7 +127,7 @@ elif a.get('order'):
 		# Removes the indicated coin above from the bag only if there is enough coin to do so
 		error, coins = handle_coins(costs, ctype)
 		if error:
-			coinsDisp=str(coins).strip("}{").replace("'","").replace(",","\n")
+			coinsDisp="\n".join([f"{coin}: {value}" for coin, value in coins.items()])
 
 			text = f''' -title "Lacking Funds!" -desc "Sorry {name}, but you do not have enough coin to purchase a {drink.fancyName}!" -f "{name}'s Coins|{coinsDisp}"'''
 			return text

--- a/consume.alias
+++ b/consume.alias
@@ -4,6 +4,12 @@ A = &ARGS&
 a = argparse(A)
 text = ''
 ch = character()
+
+DEFAULT_COIN_RATES = {"cp":100,"sp":10,"ep":2,"gp":1,"pp":0.1}
+COIN_RATES = get_svar("coinRates") or get("coinRates", DEFAULT_COIN_RATES)
+COIN_TYPES = list(COIN_RATES)
+coinPouchName = get_svar("coinPouchName") or get("coinPouchName","Coin Pouch")
+
 if not A or a.get('help', a.get('?')):
 	ar,cc,cf,ch=argparse(&ARGS&),"Intoxication Points","Drunkeness",character()
 	ch.create_cc_nx(cc,0,15,'long',reset_to=0),ch.create_cc_nx(cf,0,5,'long','bubble',reset_to=0)
@@ -14,6 +20,55 @@ if not A or a.get('help', a.get('?')):
 	text += f''' -f "__**Intoxication Levels**__" -f "Level 1: *Tipsy*|Tipsy means you gain advantage on all Charisma checks, but disadvantage on all Intelligence checks" -f "Level 2: *Drunk*|Drunk means you are under the effects of tipsy, and have advantage on all Strength attacks and checks but disadvantage on all Dexterity attacks and checks." -f "Level 3: *Alcohol Poisoning*|Alcohol Poisoning now means you have disadvantage on all attack rolls. You are no longer under the effects of Tipsy or Drunk" -f "Level 4: *Heavy Alcohol Poisoning*|Heavy Alcohol Poisoning means you are still under the effects of Alcohol Poisoning and your movement speed is now halved." -f "Level 5: *Blacked Out Drunk*|You are now Incapacitated."'''
 	text += f''' -f "Drink Responsibly!" -color <color> -thumb <image> -f "Check out `!consume updates` for updates, and you can get the `!coins` alias off the [support server](https://discord.gg/HtFqV3p7QN)." -footer "{ctx.prefix}{ctx.alias} | Adalbär#3333" -thumb "https://cdn.discordapp.com/attachments/792699041502593025/793347046333218876/beers.png"'''
 	return text
+	
+def handle_coins(costs, ctype=COIN_TYPES[0]):
+	bagsLoaded = load_json(get('bags', ''))
+	maybepouch = [i for i in bagsLoaded if i[0] == 'Coin Pouch'] or COIN_RATES != DEFAULT_COIN_RATES and [["Coin Pouch", {"cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0}]]
+	if maybepouch:
+		pouch = maybepouch[0]
+		if pouch not in bagsLoaded:
+			bagsLoaded.append(pouch)
+			pouch = [i for i in bagsLoaded if i[0] == 'Coin Pouch'][0]
+		coins = pouch[1]
+		coins.update({ctype:coins[ctype]+costs})
+		
+		for coin in coinTypes[:-1]: # for each coin type except for the last one
+			larger = coinTypes[coinTypes.index(coin)+1] # get the coin type that is one larger (cp -> sp, etc)
+			rate = int(coinRates[coin]/coinRates[larger]) # find the rate between the current coin and the larger coin. (cp/sp = 100/10=10)
+			p = coins[coin]//rate # find the new value by dividing the current amount of coins by the rate
+			if coins[coin] < 0: # if our coin subtraction brought this coin type below 0 coins:
+				coins.update( # Update our coin pouch
+				{
+					larger:coins[larger]+p, # Subtract the new value to the larger coin type (since p is negative)
+					coin:coins[coin]-p*rate # Add the new value multiplied by the rate to the smaller coin type
+				} 
+				)
+		# If they dont have the coin, it errors.
+		error = any([coins[x]<0 for x in coins])
+		if not error:
+			character().set_cvar("bags",dump_json(bagsLoaded))
+		
+	else:
+		purse = character().coinpurse
+		delta = parse_coins(f"{costs}{ctype}")
+		if not (error:=-delta.total > purse.total):
+			purse.modify_coins(delta.pp, delta.gp, delta.ep, delta.sp, delta.cp)
+		coins = {coin:purse[coin] for coin in COIN_TYPES}
+	return error, coins
+	
+def get_coins():
+	bagsLoaded = load_json(get('bags', ''))
+	maybepouch = [i for i in bagsLoaded if i[0] == 'Coin Pouch'] or COIN_RATES != DEFAULT_COIN_RATES and [["Coin Pouch", {"cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0}]]
+	if maybepouch:
+		pouch = maybepouch[0]
+		if pouch not in bagsLoaded:
+			bagsLoaded.append(pouch)
+			pouch = [i for i in bagsLoaded if i[0] == 'Coin Pouch'][0]
+		coins = pouch[1]
+	else:
+		purse = character().coinpurse
+		coins = {coin:purse[coin] for coin in COIN_TYPES}
+	return coins
 
 drinks = load_json(get_gvar('c3c5c125-2284-4793-9443-213fc9dd9877'))
 svar = get_svar('hbConsume', '[]') if ctx.guild else '[]'
@@ -42,9 +97,6 @@ ctype= (drink["coinType"] if drink else "")
 INTOX= (int(drink["intox"])if drink else "")
 # Stores the arguments for later parsing, sets the name of the two CC and collects the constitutionMod
 ar,cc,cf,con,ch=argparse(&ARGS&),"Intoxication Points","Drunkeness",constitutionMod,character()
-bagsLoaded=load_json(get('bags', '[["Coin Pouch", {"cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0}]]'))
-coins=[i for i in bagsLoaded if ("Coin" in i[0])][0]
-noCoins = coins
 
 if any(x in &ARGS& for x in ["ignore", "-i", "free"]):
 	# Error Checking
@@ -68,77 +120,29 @@ if any(x in &ARGS& for x in ["ignore", "-i", "free"]):
 	# String to display based on whether they are making saves or not
 	p="**Intoxication Points Before Saves:** "+str(x) if x>=0 else "**Constitution Save DC: "+str(dc)+"**  "+str(d)
 	# Clean up the coins bag to display
-	coinsDisp=str(coins[1]).strip("}{").replace("'","").replace(",","\n")
+	coinsDisp="\n".join([f"{coin}: {value}" for coin, value in get_coins().items()])
 
 elif a.get('order'):
 	if not any(x in &ARGS& for x in ['ignore', '-i', 'free']):
 		# Removes the indicated coin above from the bag only if there is enough coin to do so
-		bagsLoaded=load_json(get('bags', '[["Coin Pouch", {"cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0}]]'))
-		coins,ct=[i for i in bagsLoaded if ("Coin" in i[0])][0],ctype
-		coins in bagsLoaded or bagsLoaded.append(coins)
-		coins[1].update({ct:coins[1][ct]+(costs)})
-		coinTypes=["cp","sp","ep","gp","pp"]
-		coinRates={"cp":100,"sp":10,"ep":2,"gp":1,"pp":0.1}
-		coinPouchName="Coin Pouch"
-		newPouch=[[coinPouchName,{x:0 for x in coinTypes}]]
-		pouch=([x for x in bagsLoaded if x[0]==coinPouchName] or newPouch)[0]
-
-		for coin in coinTypes[:-1]: # for each coin type except for the last one
-			larger = coinTypes[coinTypes.index(coin)+1] # get the coin type that is one larger (cp -> sp, etc)
-			rate = int(coinRates[coin]/coinRates[larger]) # find the rate between the current coin and the larger coin. (cp/sp = 100/10=10)
-			p = pouch[1][coin]//rate # find the new value by dividing the current amount of coins by the rate
-			if pouch[1][coin] < 0: # if our coin subtraction brought this coin type below 0 coins:
-				pouch[1].update( # Update our coin pouch
-				{
-					larger:pouch[1][larger]+p, # Subtract the new value to the larger coin type (since p is negative)
-					coin:pouch[1][coin]-p*rate # Add the new value multiplied by the rate to the smaller coin type
-				} 
-				)
-		# If they dont have the coin, it errors. 
-		error=[x for x in pouch[1]if pouch[1][x]<0]
+		error, coins = handle_coins(costs, ctype)
 		if error:
-			coinsDisp=str(noCoins[1]).strip("}{").replace("'","").replace(",","\n")
+			coinsDisp=str(coins).strip("}{").replace("'","").replace(",","\n")
 
 			text = f''' -title "Lacking Funds!" -desc "Sorry {name}, but you do not have enough coin to purchase a {drink.fancyName}!" -f "{name}'s Coins|{coinsDisp}"'''
 			return text
-		else:
-			ch.set_cvar("bags",dump_json(bagsLoaded))
-	coinsDisp=str(coins[1]).strip("}{").replace("'","").replace(",","\n")
+	coinsDisp="\n".join([f"{coin}: {value}" for coin, value in coins.items()])
 	text += f''' -title "{name} Bought A {drink["fancyName"]}{f""" for {a.last('for')}""" if a.get('for') else ''}!" -desc "{drink['desc']}" -f "{'**Costs:** Free!' if any(x in &ARGS& for x in ['ignore', '-i', 'free']) else f'**Costs:** {costs}{ctype}'}" -f "**Coins**|{coinsDisp}"'''
 	return text
 
 else:
 	# Removes the indicated coin above from the bag only if there is enough coin to do so
-	bagsLoaded=load_json(get('bags', '[["Coin Pouch", {"cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0}]]'))
-	coins,ct=[i for i in bagsLoaded if ("Coin" in i[0])][0],ctype
-	coins in bagsLoaded or bagsLoaded.append(coins)
-	coins[1].update({ct:coins[1][ct]+(costs)})
-	coinTypes=["cp","sp","ep","gp","pp"]
-	coinRates={"cp":100,"sp":10,"ep":2,"gp":1,"pp":0.1}
-	coinPouchName="Coin Pouch"
-	newPouch=[[coinPouchName,{x:0 for x in coinTypes}]]
-	pouch=([x for x in bagsLoaded if x[0]==coinPouchName] or newPouch)[0]
-
-	for coin in coinTypes[:-1]: # for each coin type except for the last one
-		larger = coinTypes[coinTypes.index(coin)+1] # get the coin type that is one larger (cp -> sp, etc)
-		rate = int(coinRates[coin]/coinRates[larger]) # find the rate between the current coin and the larger coin. (cp/sp = 100/10=10)
-		p = pouch[1][coin]//rate # find the new value by dividing the current amount of coins by the rate
-		if pouch[1][coin] < 0: # if our coin subtraction brought this coin type below 0 coins:
-			pouch[1].update( # Update our coin pouch
-			{
-				larger:pouch[1][larger]+p, # Subtract the new value to the larger coin type (since p is negative)
-				coin:pouch[1][coin]-p*rate # Add the new value multiplied by the rate to the smaller coin type
-			} 
-			)
-	# If they dont have the coin, it errors. 
-	error=[x for x in pouch[1]if pouch[1][x]<0]
+	error, coins = handle_coins(costs, ctype)
 	if error:
-		coinsDisp=str(noCoins[1]).strip("}{").replace("'","").replace(",","\n")
+		coinsDisp="\n".join([f"{coin}: {value}" for coin, value in coins.items()])
 
 		text = f''' -title "Lacking Funds!" -desc "Sorry {name}, but you do not have enough coin to purchase a {drink.fancyName}!" -f "{name}'s Coins|{coinsDisp}"'''
 		return text
-	else:
-		ch.set_cvar("bags",dump_json(bagsLoaded))
 
 	# Error Checking
 	helpOk=True if ar.get("help") or ar.get("Help") or ar.get("?") else False
@@ -170,7 +174,7 @@ else:
 	p="**Intoxication Points Before Saves:** "+str(x) if x>=0 else "**Constitution Save DC: "+str(dc)+"**  "+str(d)
 
 	# Clean up the coins bag to display
-	coinsDisp=str(coins[1]).strip("}{").replace("'","").replace(",","\n")
+	coinsDisp="\n".join([f"{coin}: {value}" for coin, value in coins.items()])
 status = f' -f "{name} is Tipsy:| {name} gains advantage on all Charisma Checks, but disadvantage on all Intelligence checks. "' if ch.get_cc(cf)==1 else f'-f "{name} is drunk:| {name} is under the same effects as tipsy, but they now have advantage on all Strength checks but disadvantage on all Dexterity checks."' if ch.get_cc(cf)==2 else f'-f "{name} has Alcohol Poisioning:| {name} has disadvantage on all attack rolls and ability checks"' if ch.get_cc(cf)==3 else f'-f "{name} has Heavy Alcohol Poisioning:| {name} is still under the effect of Alcohol Poisioning, but their speed is now halved."' if ch.get_cc(cf)==4 else f'-f "{name} has blacked out drunk: | {name} is now incapacitated."' if ch.get_cc(cf)==5 else ""
 text += f''' -title "{name} consumes a {drink["fancyName"] if drink else ''}!" -desc "{(drink['desc'] if drink else '')}" -f "{'**Costs:** Free!' if any(x in &ARGS& for x in ['ignore', '-i', 'free']) else f'**Costs:** -{abs(int(costs))}{ctype}'}" -f "**Coins**|{coinsDisp}" -f "**Intoxication Factor:** +{INTOX}\n**Intoxication Points:** {ch.get_cc(cc)}\n**Drunkeness Points:** {ch.cc_str(cf)}\n{p}" {status} -color <color> -thumb <image>'''
 return text 


### PR DESCRIPTION
Adds support for side-by-side coinpurse and coin pouch support with new functions `get_coins()` and `handle_coins(coins, ctype)`
Modifies the coinDisp to not be reliant on stringifying a dict, and instead using list comprehension so it's a bit more readable.